### PR TITLE
Fix broken headings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-#MatrixComputation
+# MatrixComputation
 
 *The project performs a benchmark test for matrices computation in Java, C++, Eigen, OpenCV, RenderScript on Android platform*
 
 *The purpose of this application is not to compare the performance of algorithms performing matrix multiplication. All computations are implemented in naive way*
 
 ======
-###CONTENT
+### CONTENT
 1. [Application Manifest] (#1)
 2. [Java] (#2)
 3. [C++] (#3)
@@ -15,7 +15,7 @@
 7. [Contacts] (#7)
 
 ======
-###<a name="1"></a>APPLICATION MANIFEST
+### <a name="1"></a>APPLICATION MANIFEST
 - Target SDK Version: 19
 - Minimum SDK Version: 16
 - Uses Permission
@@ -24,23 +24,23 @@
   - android.permission.READ_LOGS
 
 
-###<a name="2"></a>Java
+### <a name="2"></a>Java
 This is the simplest way to perform matrices computation on Android devices. Yet, the performance is the worst among all approaches demonstrated in this application.
 
-###<a name="3"></a>C++
+### <a name="3"></a>C++
 This approach is faster than Java. Note that [Java Native Interface](http://docs.oracle.com/javase/7/docs/technotes/guides/jni/) is needed in order to run native code in Android applications.
 
-###<a name="4"></a>OpenCV
+### <a name="4"></a>OpenCV
 [OpenCV](http://opencv.org/) is common library for mathematic computations. Details and tutorial about [OpenCV on Android] (http://opencv.org/platforms/android.html) can be found [here] (http://docs.opencv.org/doc/tutorials/introduction/android_binary_package/O4A_SDK.html).
 ***NOTE*** *OpenCV is not available in release 1.2*
 
-###<a name="5"></a>Eigen
+### <a name="5"></a>Eigen
 [Eigen] (http://eigen.tuxfamily.org/index.php?title=Main_Page) is another choice for computation. Eigen usually outperform OpenCV on Android devices.
 
-###<a name="6"></a>RenderScript
+### <a name="6"></a>RenderScript
 [RenderScript] (http://developer.android.com/guide/topics/renderscript/compute.html) is a framework for running computationally intensive tasks at high performance on Android, usually used for image processing on Android devices. It accelerates the computation by running on GPUs. Please note that RenderScript is device-dependent. Version problem limits the compatibility of RenderScript.
 
 ======
-###<a name="7"></a>Contacts
+### <a name="7"></a>Contacts
 Ching-Lun Lin,
 clallenlin@sv.cmu.edu, 2014


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
